### PR TITLE
fix: erroneous invert

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MetabolicAtlas/3d-network-viewer/issues"
   },
   "name": "@metabolicatlas/3d-network-viewer",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },

--- a/src/met-atlas-viewer.js
+++ b/src/met-atlas-viewer.js
@@ -503,7 +503,7 @@ function MetAtlasViewer(targetElement) {
         testCamera.lookAt(0,0,0);
         testCamera.updateMatrix();
         testCamera.updateMatrixWorld();
-        testCamera.matrixWorldInverse.invert( testCamera.matrixWorld );
+        testCamera.matrixWorldInverse.copy(testCamera.matrixWorld).invert();
 
         while (!isInCamera(items, testCamera) && cameraDistance < maxDistance) {
           // move camera back until we've reached the max distance or we can see
@@ -519,7 +519,7 @@ function MetAtlasViewer(targetElement) {
           testCamera.lookAt(0,0,0);
           testCamera.updateMatrix();
           testCamera.updateMatrixWorld();
-          testCamera.matrixWorldInverse.invert( testCamera.matrixWorld );
+          testCamera.matrixWorldInverse.copy(testCamera.matrixWorld).invert();
         }
       }
       setFlyTarget(t);
@@ -949,7 +949,7 @@ function MetAtlasViewer(targetElement) {
     testCamera.lookAt(cameraControls.target);
     testCamera.updateMatrix();
     testCamera.updateMatrixWorld();
-    testCamera.matrixWorldInverse.invert( testCamera.matrixWorld );
+    testCamera.matrixWorldInverse.copy(testCamera.matrixWorld).invert();
 
     let frustum = new Frustum();
     frustum.setFromProjectionMatrix(


### PR DESCRIPTION
The change from `getInverse` to `invert` was done incorrectly. Now it is done according to the linter recommendation. This should resolve [the problem with labels being misplaced](https://github.com/MetabolicAtlas/MetabolicAtlas/pull/666#pullrequestreview-719447744).