### PR TITLE
feat: color individual nodes without redrawing the whole graph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metabolicatlas/3d-network-viewer",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@metabolicatlas/3d-network-viewer",
-      "version": "0.1.28",
+      "version": "0.1.29",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MetabolicAtlas/3d-network-viewer/issues"
   },
   "name": "@metabolicatlas/3d-network-viewer",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -179,7 +179,7 @@ const moveCamera = (
  * @param {Array} fallbackColor - fallback color to set the object to
  */
 const getColor = (isSelected, color, fallbackSelectedColor, fallbackColor) =>
-  color || isSelected ? fallbackSelectedColor : fallbackColor;
+  color || (isSelected ? fallbackSelectedColor : fallbackColor);
 
 /*
  * Get node color.

--- a/src/met-atlas-viewer.js
+++ b/src/met-atlas-viewer.js
@@ -371,6 +371,7 @@ const MetAtlasViewer = targetElement => {
         setSpriteColor(index, colorData[n.id]);
       }
     });
+    animationId = requestAnimationFrame(render);
   };
 
   /**

--- a/src/met-atlas-viewer.js
+++ b/src/met-atlas-viewer.js
@@ -365,7 +365,7 @@ const MetAtlasViewer = targetElement => {
     });
   };
 
-  const updateNodeColors = async colorData => {
+  const updateNodeColors = colorData => {
     nodeInfo.map((n, index) => {
       if (colorData[n.id]) {
         setSpriteColor(index, colorData[n.id]);

--- a/src/met-atlas-viewer.js
+++ b/src/met-atlas-viewer.js
@@ -365,6 +365,14 @@ const MetAtlasViewer = targetElement => {
     });
   };
 
+  const updateNodeColors = async colorData => {
+    nodeInfo.map((n, index) => {
+      if (colorData[n.id]) {
+        setSpriteColor(index, colorData[n.id]);
+      }
+    });
+  };
+
   /**
    * Sets the default colors
    *
@@ -744,6 +752,7 @@ const MetAtlasViewer = targetElement => {
       color,
       nodeInfo[spriteNum].color
     );
+
     updateColorInMesh(nodeMesh, spriteNum, c);
     nodeMesh.geometry.attributes.color.needsUpdate = true;
   };
@@ -1191,6 +1200,7 @@ const MetAtlasViewer = targetElement => {
     setLabelDistance,
     toggleLabels,
     toggleNodeType,
+    updateNodeColors,
     exportImage,
   };
 };


### PR DESCRIPTION
This is intended to be used with [MetAtlas PR 1204](https://github.com/MetabolicAtlas/MetabolicAtlas/pull/1204)

Adds a function that lets you color a list of nodes using `setSpriteColor` directly.