### PR TITLE
fix: enable selecting nodes on mobile devices

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@metabolicatlas/3d-network-viewer",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@metabolicatlas/3d-network-viewer",
-      "version": "0.1.33",
+      "version": "0.1.34",
       "license": "GPL-3.0-only",
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^15.0.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MetabolicAtlas/3d-network-viewer/issues"
   },
   "name": "@metabolicatlas/3d-network-viewer",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "publishConfig": {
     "registry": "https://registry.npmjs.org"
   },

--- a/src/met-atlas-viewer.js
+++ b/src/met-atlas-viewer.js
@@ -1186,6 +1186,11 @@ const MetAtlasViewer = targetElement => {
     false
   );
   renderer.domElement.addEventListener(
+    'touchstart',
+    () => (cursorInContainer = true),
+    false
+  );
+  renderer.domElement.addEventListener(
     'mouseleave',
     () => (cursorInContainer = false),
     false


### PR DESCRIPTION
This PR closes issue #65.

Mobile users can now select nodes in the network.

**Testing**
- To use this fix in MetabolicAtlas:
1. Change value for dependency from version number to git branch in `frontend/package.json`.
```json
    "@metabolicatlas/3d-network-viewer": "MetabolicAtlas/3d-network-viewer#fix/3d-clicking-on-mobile",
```

2.  Install the dependency and build it.
```bash
docker-compose --env-file env-local.env -f docker-compose.yml -f docker-compose-local.yml up -d --no-deps --build frontend
ma-exec frontend npm --prefix node_modules/@metabolicatlas/3d-network-viewer/ install
ma-exec frontend npm --prefix node_modules/@metabolicatlas/3d-network-viewer/ run build
```

- To try this on your mobile, see @e0's post below about [ngrok](ngrok.com). Very easy to use!

- Try clicking nodes either in the 3d map viewer or at Interaction Partners.
- Make sure everything works on standard browser and mobile devices, and that no bugs (eg [labels being shown outside of the map window](https://github.com/MetabolicAtlas/MetabolicAtlas/issues/1172)) are reintroduced.

**Further comments:**
The reason node selection does not work on mobile devices is that they do not send `mouseenter` or `mouseleave` events, so `cursorInContainer` is never set to true, see [this](https://github.com/MetabolicAtlas/3d-network-viewer/blob/main/src/met-atlas-viewer.js#L1185) and [this code](https://github.com/MetabolicAtlas/3d-network-viewer/blob/main/src/met-atlas-viewer.js#L552).
In this solution, `cursorInContainer` is set to `true` as soon as a touch event is sent. This seems to work fine at least when emulating mobile devices from my computer, although you might have to click twice the very first time. I suspect that it might work even better on a real mobile device. There are of course other ways of doing this, such as trying to to detect if the client uses a mobile device (see [examples here](https://stackoverflow.com/questions/11381673/detecting-a-mobile-browser)), but I'm a bit hesitant to that approach, since it seems to be error prone, eg not covering all devices. 
